### PR TITLE
Sensor status

### DIFF
--- a/pyalarmdotcom/pyalarmdotcom.py
+++ b/pyalarmdotcom/pyalarmdotcom.py
@@ -73,6 +73,7 @@ class Alarmdotcom(object):
     
     ARMING_PANEL = '#ctl00_phBody_pnlArming'
     ALARM_STATE = '#ctl00_phBody_lblArmingState'
+    SENSOR_STATUS = '#ctl00_phBody_lblSensorStatus'
 
     COMMAND_LIST = {'Disarm': {'command': DISARM_COMMAND,
                            'eventvalidation': DISARM_EVENT_VALIDATION},
@@ -96,6 +97,7 @@ class Alarmdotcom(object):
         self._loop = loop
         self._login_info = None
         self.state = None
+        self.sensor_status = None
 
     @asyncio.coroutine
     def async_login(self):
@@ -160,10 +162,12 @@ class Alarmdotcom(object):
            _LOGGER.debug(text)
            tree = BeautifulSoup(text, 'html.parser')
            try:
-               # Get the initial state.
                self.state = tree.select(self.ALARM_STATE)[0].get_text()
                _LOGGER.debug(
                    'Current alarm state: %s', self.state)
+               self.sensor_status = tree.select(self.SENSOR_STATUS)[0].get_text()
+               _LOGGER.debug(
+                   'Current sensor status: %s', self.sensor_status)
            except IndexError:
                try:
                    error_control = tree.select(
@@ -199,9 +203,13 @@ class Alarmdotcom(object):
                 self.state = tree.select(self.ALARM_STATE)[0].get_text()
                 _LOGGER.debug(
                     'Current alarm state: %s', self.state)
+                self.sensor_status = tree.select(self.SENSOR_STATUS)[0].get_text()
+                _LOGGER.debug(
+                    'Current sensor status: %s', self.sensor_status)
             except IndexError:
                 # We may have timed out. Re-login again
                 self.state = None
+                self.sensor_status = None
                 self._login_info = None
                 yield from self.async_update()
         except (asyncio.TimeoutError, aiohttp.errors.ClientError):


### PR DESCRIPTION
This PR adds support for loading sensor status. My current value, nicely reported via Home Assistant w/ https://github.com/jnewland/home-assistant/commit/c0f615d61477b7de3f15f7188a6041958a969246:

> All doors and windows closed.No motion activity detected.

I'm not sure if `ctl00_phBody_lblSensorStatus` is present on all users' system summary page: is it present on yours? I'd be happy to push up some changes to ensure the absence of this field is gracefully handled, or take other review suggestions. 😄 