### PR TITLE
Added another version which scrapes via Ajax

### DIFF
--- a/pyalarmdotcom/pyalarmdotcom.py
+++ b/pyalarmdotcom/pyalarmdotcom.py
@@ -291,7 +291,7 @@ class Alarmdotcom(object):
                     if event == 'Disarm':
                         yield from self.async_alarm_disarm()
                     elif event == 'Arm+Stay':
-                        yield from self.async_alarm_arm_away()
+                        yield from self.async_alarm_arm_home()
                     elif event == 'Arm+Away':
                         yield from self.async_alarm_arm_away()
 

--- a/pyalarmdotcom/pyalarmdotcomajax.py
+++ b/pyalarmdotcom/pyalarmdotcomajax.py
@@ -40,7 +40,13 @@ class Alarmdotcom(object):
     }
 
     def __init__(
-        self, username, password, websession, loop, forcebypass=False, noentrydelay=False
+        self,
+        username,
+        password,
+        websession,
+        loop,
+        forcebypass=False,
+        noentrydelay=False,
     ):
         """
         Use aiohttp to make a request to alarm.com
@@ -53,7 +59,9 @@ class Alarmdotcom(object):
         self._username = username
         self._password = password
         self._websession = websession
-        self.state = ""  # empty string instead of None so lower() in alarm_control_panel doesn't complain
+        self.state = (
+            ""
+        )  # empty string instead of None so lower() in alarm_control_panel doesn't complain
         self.sensor_status = None
         self._ajax_headers = {
             "Accept": "application/vnd.api+json",
@@ -115,7 +123,7 @@ class Alarmdotcom(object):
         except (asyncio.TimeoutError, aiohttp.ClientError):
             _LOGGER.error("Can not login to Alarm.com")
             return False
-        except AttributeError:
+        except KeyError:
             _LOGGER.error("Unable to extract ajax key from Alarm.com")
             raise
         try:
@@ -128,7 +136,7 @@ class Alarmdotcom(object):
         except (asyncio.TimeoutError, aiohttp.ClientError):
             _LOGGER.error("Can not load system data from Alarm.com")
             return False
-        except (AttributeError, IndexError):
+        except (KeyError, IndexError):
             _LOGGER.error("Unable to extract system id from Alarm.com")
             raise
         try:
@@ -143,7 +151,7 @@ class Alarmdotcom(object):
         except (asyncio.TimeoutError, aiohttp.ClientError):
             _LOGGER.error("Can not load partition data from Alarm.com")
             return False
-        except (AttributeError, IndexError):
+        except (KeyError, IndexError):
             _LOGGER.error("Unable to extract partition id from Alarm.com")
             raise
         return True
@@ -172,7 +180,7 @@ class Alarmdotcom(object):
         except (asyncio.TimeoutError, aiohttp.ClientError):
             _LOGGER.error("Can not load state data from Alarm.com")
             return False
-        except AttributeError:
+        except KeyError:
             _LOGGER.error("Unable to extract state data from Alarm.com")
             raise
         try:
@@ -187,7 +195,7 @@ class Alarmdotcom(object):
         except (asyncio.TimeoutError, aiohttp.ClientError):
             _LOGGER.error("Can not load trouble conditions from Alarm.com")
             return False
-        except AttributeError:
+        except KeyError:
             _LOGGER.error("Unable to extract trouble conditions from Alarm.com")
             raise
         return True

--- a/pyalarmdotcom/pyalarmdotcomajax.py
+++ b/pyalarmdotcom/pyalarmdotcomajax.py
@@ -1,0 +1,246 @@
+import aiohttp
+from bs4 import BeautifulSoup
+import asyncio
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class Alarmdotcom(object):
+    """
+    Access to alarm.com partners and accounts.
+
+    This class is used to interface with the options available through
+    alarm.com. The basic functions of checking system status and arming
+    and disarming the system are possible.
+    """
+
+    LOGIN_URL = "https://www.alarm.com/login"
+    LOGIN_USERNAME_FIELD = "ctl00$ContentPlaceHolder1$loginform$txtUserName"
+    LOGIN_PASSWORD_FIELD = "txtPassword"
+    LOGIN_POST_URL = "https://www.alarm.com/web/Default.aspx"
+    VIEWSTATE_FIELD = "__VIEWSTATE"
+    VIEWSTATEGENERATOR_FIELD = "__VIEWSTATEGENERATOR"
+    EVENTVALIDATION_FIELD = "__EVENTVALIDATION"
+    PREVIOUSPAGE_FIELD = "__PREVIOUSPAGE"
+    SYSTEMITEMS_URL = "https://www.alarm.com/web/api/systems/availableSystemItems"
+    SYSTEM_URL_BASE = "https://www.alarm.com/web/api/systems/systems/"
+    PARTITION_URL_BASE = "https://www.alarm.com/web/api/devices/partitions/"
+    TROUBLECONDITIONS_URL = "https://www.alarm.com/web/api/troubleConditions/troubleConditions?forceRefresh=false"
+    STATEMAP = (
+        "",
+        "disarmed",
+        "armed stay",
+        "armed away",
+    )  # index is ADC's json status, value is integration's status
+    COMMAND_LIST = {
+        "Disarm": {"command": "disarm"},
+        "Arm+Stay": {"command": "armStay"},
+        "Arm+Away": {"command": "armAway"},
+    }
+
+    def __init__(
+        self, username, password, websession, loop, forcebypass=False, noentrydelay=False
+    ):
+        """
+        Use aiohttp to make a request to alarm.com
+
+        :param username: Alarm.com username
+        :param password: Alarm.com password
+        :param websession: AIOHttp Websession
+        :param loop: Async loop.
+        """
+        self._username = username
+        self._password = password
+        self._websession = websession
+        self.state = ""  # empty string instead of None so lower() in alarm_control_panel doesn't complain
+        self.sensor_status = None
+        self._ajax_headers = {
+            "Accept": "application/vnd.api+json",
+            "ajaxrequestuniquekey": None,
+        }
+        self._systemid = None
+        self._partitionid = None
+        self._forcebypass = forcebypass
+        self._noentrydelay = noentrydelay
+
+    async def async_login(self):
+        """Login to Alarm.com."""
+        _LOGGER.debug("Attempting to log into Alarm.com...")
+        try:
+            # load login page once and grab VIEWSTATE/cookies
+            async with self._websession.get(url=self.LOGIN_URL) as resp:
+                text = await resp.text()
+                _LOGGER.debug("Response status from Alarm.com: %s", resp.status)
+                tree = BeautifulSoup(text, "html.parser")
+                login_info = {
+                    self.VIEWSTATE_FIELD: tree.select(
+                        "#{}".format(self.VIEWSTATE_FIELD)
+                    )[0].attrs.get("value"),
+                    self.VIEWSTATEGENERATOR_FIELD: tree.select(
+                        "#{}".format(self.VIEWSTATEGENERATOR_FIELD)
+                    )[0].attrs.get("value"),
+                    self.EVENTVALIDATION_FIELD: tree.select(
+                        "#{}".format(self.EVENTVALIDATION_FIELD)
+                    )[0].attrs.get("value"),
+                    self.PREVIOUSPAGE_FIELD: tree.select(
+                        "#{}".format(self.PREVIOUSPAGE_FIELD)
+                    )[0].attrs.get("value"),
+                }
+                _LOGGER.debug(login_info)
+                _LOGGER.info("Attempting login to Alarm.com")
+        except (asyncio.TimeoutError, aiohttp.ClientError):
+            _LOGGER.error("Can not load login page from Alarm.com")
+            return False
+        except (AttributeError, IndexError):
+            _LOGGER.error("Unable to extract login info from Alarm.com")
+            raise
+        try:
+            # login and grab ajax key
+            async with self._websession.post(
+                url=self.LOGIN_POST_URL,
+                data={
+                    self.LOGIN_USERNAME_FIELD: self._username,
+                    self.LOGIN_PASSWORD_FIELD: self._password,
+                    self.VIEWSTATE_FIELD: login_info[self.VIEWSTATE_FIELD],
+                    self.VIEWSTATEGENERATOR_FIELD: login_info[
+                        self.VIEWSTATEGENERATOR_FIELD
+                    ],
+                    self.EVENTVALIDATION_FIELD: login_info[self.EVENTVALIDATION_FIELD],
+                    self.PREVIOUSPAGE_FIELD: login_info[self.PREVIOUSPAGE_FIELD],
+                    "IsFromNewSite": "1",
+                },
+            ) as resp:
+                self._ajax_headers["ajaxrequestuniquekey"] = resp.cookies["afg"].value
+        except (asyncio.TimeoutError, aiohttp.ClientError):
+            _LOGGER.error("Can not login to Alarm.com")
+            return False
+        except AttributeError:
+            _LOGGER.error("Unable to extract ajax key from Alarm.com")
+            raise
+        try:
+            # grab system id
+            async with self._websession.get(
+                url=self.SYSTEMITEMS_URL, headers=self._ajax_headers
+            ) as resp:
+                json = await (resp.json())
+            self._systemid = json["data"][0]["id"]
+        except (asyncio.TimeoutError, aiohttp.ClientError):
+            _LOGGER.error("Can not load system data from Alarm.com")
+            return False
+        except (AttributeError, IndexError):
+            _LOGGER.error("Unable to extract system id from Alarm.com")
+            raise
+        try:
+            # grab partition id
+            async with self._websession.get(
+                url=self.SYSTEM_URL_BASE + self._systemid, headers=self._ajax_headers
+            ) as resp:
+                json = await (resp.json())
+            self._partitionid = json["data"]["relationships"]["partitions"]["data"][0][
+                "id"
+            ]
+        except (asyncio.TimeoutError, aiohttp.ClientError):
+            _LOGGER.error("Can not load partition data from Alarm.com")
+            return False
+        except (AttributeError, IndexError):
+            _LOGGER.error("Unable to extract partition id from Alarm.com")
+            raise
+        return True
+
+    async def async_update(self):
+        """Fetch the latest state."""
+        _LOGGER.debug("Calling update on Alarm.com")
+        try:
+            # grab partition status
+            async with self._websession.get(
+                url=self.PARTITION_URL_BASE + self._partitionid,
+                headers=self._ajax_headers,
+            ) as resp:
+                json = await (resp.json())
+            self.sensor_status = json["data"]["attributes"]["needsClearIssuesPrompt"]
+            self.sensor_status = (
+                "System needs to be cleared" if self.sensor_status else "System OK"
+            )
+            self.state = json["data"]["attributes"]["state"]
+            self.state = self.STATEMAP[self.state]
+            _LOGGER.debug(
+                "Got state %s, mapping to %s",
+                json["data"]["attributes"]["state"],
+                self.state,
+            )
+        except (asyncio.TimeoutError, aiohttp.ClientError):
+            _LOGGER.error("Can not load state data from Alarm.com")
+            return False
+        except AttributeError:
+            _LOGGER.error("Unable to extract state data from Alarm.com")
+            raise
+        try:
+            async with self._websession.get(
+                url=self.TROUBLECONDITIONS_URL, headers=self._ajax_headers
+            ) as resp:
+                json = await (resp.json())
+            for troublecondition in json["data"]:
+                self.sensor_status += (
+                    "\n" + troublecondition["attributes"]["description"]
+                )
+        except (asyncio.TimeoutError, aiohttp.ClientError):
+            _LOGGER.error("Can not load trouble conditions from Alarm.com")
+            return False
+        except AttributeError:
+            _LOGGER.error("Unable to extract trouble conditions from Alarm.com")
+            raise
+        return True
+
+    async def _send(self, event):
+        """Generic function for sending commands to Alarm.com
+
+        :param event: Event command to send to alarm.com
+        """
+        _LOGGER.debug("Sending %s to Alarm.com", event)
+        if event == "Disarm":
+            json = {"statePollOnly": "false"}
+        else:
+            json = {
+                "forceBypass": self._forcebypass,
+                "noEntryDelay": self._noentrydelay,
+                "statePollOnly": "false",
+            }
+        try:
+            async with self._websession.post(
+                url=self.PARTITION_URL_BASE
+                + self._partitionid
+                + "/"
+                + self.COMMAND_LIST[event]["command"],
+                json=json,
+                headers=self._ajax_headers,
+            ) as resp:
+                _LOGGER.debug("Response from Alarm.com %s", resp.status)
+                if resp.status == 200:
+                    # Update alarm.com status after calling state change.
+                    await self.async_update()
+                elif resp.status >= 400:
+                    raise aiohttp.ClientError
+        except aiohttp.ClientError:
+            # May have been logged out, try again
+            _LOGGER.error("Error executing %s, logging in and trying again...", event)
+            await self.async_login()
+            if event == "Disarm":
+                await self.async_alarm_disarm()
+            elif event == "Arm+Stay":
+                await self.async_alarm_arm_home()
+            elif event == "Arm+Away":
+                await self.async_alarm_arm_away()
+        return True
+
+    async def async_alarm_disarm(self):
+        """Send disarm command."""
+        await self._send("Disarm")
+
+    async def async_alarm_arm_home(self):
+        """Send arm home command."""
+        await self._send("Arm+Stay")
+
+    async def async_alarm_arm_away(self):
+        """Send arm away command."""
+        await self._send("Arm+Away")

--- a/pyalarmdotcom/pyalarmdotcomajax.py
+++ b/pyalarmdotcom/pyalarmdotcomajax.py
@@ -115,7 +115,7 @@ class Alarmdotcom(object):
         except (asyncio.TimeoutError, aiohttp.ClientError):
             _LOGGER.error("Can not login to Alarm.com")
             return False
-        except AttributeError:
+        except KeyError:
             _LOGGER.error("Unable to extract ajax key from Alarm.com")
             raise
         try:
@@ -128,7 +128,7 @@ class Alarmdotcom(object):
         except (asyncio.TimeoutError, aiohttp.ClientError):
             _LOGGER.error("Can not load system data from Alarm.com")
             return False
-        except (AttributeError, IndexError):
+        except (KeyError, IndexError):
             _LOGGER.error("Unable to extract system id from Alarm.com")
             raise
         try:
@@ -143,7 +143,7 @@ class Alarmdotcom(object):
         except (asyncio.TimeoutError, aiohttp.ClientError):
             _LOGGER.error("Can not load partition data from Alarm.com")
             return False
-        except (AttributeError, IndexError):
+        except (KeyError, IndexError):
             _LOGGER.error("Unable to extract partition id from Alarm.com")
             raise
         return True
@@ -172,7 +172,7 @@ class Alarmdotcom(object):
         except (asyncio.TimeoutError, aiohttp.ClientError):
             _LOGGER.error("Can not load state data from Alarm.com")
             return False
-        except AttributeError:
+        except KeyError:
             _LOGGER.error("Unable to extract state data from Alarm.com")
             raise
         try:
@@ -187,7 +187,7 @@ class Alarmdotcom(object):
         except (asyncio.TimeoutError, aiohttp.ClientError):
             _LOGGER.error("Can not load trouble conditions from Alarm.com")
             return False
-        except AttributeError:
+        except KeyError:
             _LOGGER.error("Unable to extract trouble conditions from Alarm.com")
             raise
         return True


### PR DESCRIPTION
The existing code worked for me, but I was unable to arm using force bypass. Rewrote the code to scrape and arm via the regular site using Ajax/JSON. The general idea is the same as the old code, but there are a few more steps because the relevant information is scattered across several URLs. This version can take in optional forcebypass and noentrydelay fields to pass along to the arming events. The sensor_status is not exactly the same as the pda version, but it should reflect similar information.
I just dropped this new version in a different file because I'm not sure how Daren wants to integrate it. We should probably keep both this and the pda version as the scraping of either version may break if ADC makes changes. We can let the user pick the scraping version to use via the HA config.

